### PR TITLE
Updated for i686 arch

### DIFF
--- a/app/models/switchman/shard.rb
+++ b/app/models/switchman/shard.rb
@@ -323,7 +323,7 @@ module Switchman
               else
                 shard = partition_object.shard
               end
-            when Fixnum, /^\d+$/, /^(\d+)~(\d+)$/, Bignum
+            when Integer, /^\d+$/, /^(\d+)~(\d+)$/
               local_id, shard = Shard.local_id_for(partition_object)
               local_id ||= partition_object
               object = local_id if !partition_proc
@@ -350,7 +350,7 @@ module Switchman
           # doesn't make sense to have a double-global id
           return nil if local_id > IDS_PER_SHARD
           $1.to_i * IDS_PER_SHARD + local_id
-        when Fixnum, /^\d+$/, Bignum
+        when Integer, /^\d+$/
           any_id.to_i
         else
           nil


### PR DESCRIPTION
Per an IRC party with @simonista, it was found that Switchman expects (2 *\* 32).class to be Fixnum. On i686, it's Bignum. Since the [two](https://github.com/instructure/switchman/blob/master/app/models/switchman/shard.rb#L326) [conditionals](https://github.com/instructure/switchman/blob/master/app/models/switchman/shard.rb#L353) don't really seem to care about the subtle bitwise differences between Fixnum and Bignum, and Fixnum is architecture-specific -- and Bignum is going to cast back to integer anyway -- I'm submitting a PR to include Bignum in the aforementioned conditionals.
