### PR TITLE
update name of `schemas` method to `current_schemas`

### DIFF
--- a/lib/switchman/active_record/connection_pool.rb
+++ b/lib/switchman/active_record/connection_pool.rb
@@ -17,7 +17,7 @@ module Switchman
         raise "Not postgres!" unless self.spec.config[:adapter] == 'postgresql'
         connection unless @schemas
         # default shard will not switch databases immediately, so it won't be set yet
-        @schemas ||= connection.schemas
+        @schemas ||= connection.current_schemas
         @schemas.first
       end
 
@@ -65,7 +65,7 @@ module Switchman
 
       def switch_database(conn)
         if !@schemas && conn.adapter_name == 'PostgreSQL' && !self.shard.database_server.config[:shard_name]
-          @schemas = conn.schemas
+          @schemas = conn.current_schemas
         end
 
         spec.config[:shard_name] = self.shard.name

--- a/lib/switchman/active_record/postgresql_adapter.rb
+++ b/lib/switchman/active_record/postgresql_adapter.rb
@@ -5,7 +5,7 @@ module Switchman
         klass::NATIVE_DATABASE_TYPES[:primary_key] = "bigserial primary key".freeze
       end
 
-      def schemas
+      def current_schemas
         select_values("SELECT * FROM unnest(current_schemas(false))")
       end
     end

--- a/lib/switchman/database_server.rb
+++ b/lib/switchman/database_server.rb
@@ -255,7 +255,7 @@ module Switchman
         if shard == :bootstrap
           # rescue nil because the database may not exist yet; if it doesn't,
           # it will shortly, and this will be re-invoked
-          ::ActiveRecord::Base.connection.schemas.first rescue nil
+          ::ActiveRecord::Base.connection.current_schemas.first rescue nil
         else
           shard.activate { ::ActiveRecord::Base.connection_pool.default_schema }
         end

--- a/spec/models/shard_spec.rb
+++ b/spec/models/shard_spec.rb
@@ -257,7 +257,7 @@ module Switchman
         shard.database_server = db
         connection = mock()
         connection.stubs(:open_transactions).returns(0)
-        connection.expects(:schemas).returns(['canvas', 'public']).once
+        connection.expects(:current_schemas).returns(['canvas', 'public']).once
         connection.expects(:schema_search_path=).with(nil).once
         connection.stubs(:shard).returns(Shard.default)
         connection.expects(:shard=).with(shard)


### PR DESCRIPTION
this update (1) provides a more descriptive name, and (2) is less likely to conflict with other gems who are defining their own `schemas` method in the AR adapter.