### PR TITLE
Add :connections to ConnectionPoolProxy

### DIFF
--- a/lib/switchman/connection_pool_proxy.rb
+++ b/lib/switchman/connection_pool_proxy.rb
@@ -10,7 +10,7 @@ module Switchman
   end
 
   class ConnectionPoolProxy
-    delegate :spec, :connected?, :default_schema, :with_connection,
+    delegate :spec, :connected?, :default_schema, :with_connection, :connections,
              :to => :current_pool
 
     attr_reader :category, :schema_cache


### PR DESCRIPTION
This is necessary for DatabaseCleaner to use its :transaction strategy with Switchman.