### PR TITLE
Performance tuning investigations

### DIFF
--- a/app/models/switchman/shard.rb
+++ b/app/models/switchman/shard.rb
@@ -68,7 +68,7 @@ module Switchman
         old_shards = nil
         shards.each do |category, shard|
           next if category == :unsharded
-          unless shard == active_shards[category]
+          unless active_shards[category] == shard
             old_shards ||= {}
             old_shards[category] = active_shards[category]
             active_shards[category] = shard
@@ -587,11 +587,6 @@ module Switchman
     def global_id_for(local_id)
       return nil unless local_id
       local_id + self.id * IDS_PER_SHARD
-    end
-
-    def ==(rhs)
-      return true if rhs.is_a?(DefaultShard) && default?
-      super
     end
 
     # skip global_id.hash

--- a/app/models/switchman/shard.rb
+++ b/app/models/switchman/shard.rb
@@ -407,15 +407,16 @@ module Switchman
       # takes an id-ish, and returns a local id and the shard it's
       # local to. [nil, nil] if it can't be interpreted. [id, nil]
       # if it's already a local ID
+      NIL_NIL_ID = [nil, nil].freeze
       def local_id_for(any_id)
         id = integral_id_for(any_id)
-        return [nil, nil] unless id
+        return NIL_NIL_ID unless id
         if id < IDS_PER_SHARD
           [id, nil]
         elsif shard = lookup(id / IDS_PER_SHARD)
           [id % IDS_PER_SHARD, shard]
         else
-          [nil, nil]
+          NIL_NIL_ID
         end
       end
 

--- a/app/models/switchman/shard.rb
+++ b/app/models/switchman/shard.rb
@@ -48,6 +48,7 @@ module Switchman
 
           # Now find the actual record, if it exists; rescue the fake default if the table doesn't exist
           @default = Shard.where(default:true).first || default rescue default
+          activate!(:default => @default)
         end
         @default
       end

--- a/app/models/switchman/shard.rb
+++ b/app/models/switchman/shard.rb
@@ -66,12 +66,13 @@ module Switchman
 
       def activate!(shards)
         old_shards = nil
+        currently_active_shards = active_shards
         shards.each do |category, shard|
           next if category == :unsharded
-          unless active_shards[category] == shard
+          unless currently_active_shards[category] == shard
             old_shards ||= {}
-            old_shards[category] = active_shards[category]
-            active_shards[category] = shard
+            old_shards[category] = currently_active_shards[category]
+            currently_active_shards[category] = shard
           end
         end
         old_shards

--- a/app/models/switchman/shard.rb
+++ b/app/models/switchman/shard.rb
@@ -613,12 +613,11 @@ module Switchman
       database_server.shard_name(self)
     end
 
-    DEFAULT_CATEGORY_ONLY = [:default]
     def hashify_categories(categories)
-      if categories.empty? || categories == DEFAULT_CATEGORY_ONLY
+      if categories.empty?
         { :default => self }
       else
-        Hash[categories.flatten.map!{ |category| [category, self] }]
+        categories.inject({}) { |h, category| h[category] = self; h }
       end
     end
 

--- a/app/models/switchman/shard.rb
+++ b/app/models/switchman/shard.rb
@@ -122,7 +122,7 @@ module Switchman
       end
 
       def clear_cache
-        @cached_shards = {}
+        cached_shards.clear
       end
 
       # ==== Parameters
@@ -460,7 +460,7 @@ module Switchman
       private
       # in-process caching
       def cached_shards
-        @cached_shards ||= {}
+        @cached_shards ||= {}.compare_by_identity
       end
 
       def add_to_cache(shard)
@@ -472,7 +472,7 @@ module Switchman
       end
 
       def active_shards
-        Thread.current[:active_shards] ||= {}
+        Thread.current[:active_shards] ||= {}.compare_by_identity
       end
     end
 

--- a/app/models/switchman/shard.rb
+++ b/app/models/switchman/shard.rb
@@ -615,10 +615,13 @@ module Switchman
       database_server.shard_name(self)
     end
 
+    DEFAULT_CATEGORY_ONLY = [:default]
     def hashify_categories(categories)
-      categories = categories.flatten
-      categories << :default if categories.empty?
-      Hash[*categories.map{ |category| [category, self] }.flatten]
+      if categories.empty? || categories == DEFAULT_CATEGORY_ONLY
+        { :default => self }
+      else
+        Hash[categories.flatten.map!{ |category| [category, self] }]
+      end
     end
 
   end

--- a/lib/switchman/active_record/log_subscriber.rb
+++ b/lib/switchman/active_record/log_subscriber.rb
@@ -12,10 +12,10 @@ module Switchman
 
         payload = event.payload
 
-        return if 'SCHEMA' == payload[:name]
+        return if 'SCHEMA'.freeze == payload[:name]
 
-        name  = '%s (%.1fms)' % [payload[:name], event.duration]
-        sql   = payload[:sql].squeeze(' ')
+        name  = '%s (%.1fms)'.freeze % [payload[:name], event.duration]
+        sql   = payload[:sql].squeeze(' '.freeze)
         binds = nil
         shard = payload[:shard]
         shard = "  [#{shard[:database_server_id]}:#{shard[:id]} #{shard[:env]}]" if shard

--- a/lib/switchman/active_record/postgresql_adapter.rb
+++ b/lib/switchman/active_record/postgresql_adapter.rb
@@ -133,7 +133,7 @@ module Switchman
       end
 
       def quote_table_name name
-        if ::Rails.version < '4.2'
+        if ::Rails.version < '4.2'.freeze
           schema, name_part = extract_pg_identifier_from_name(name.to_s)
 
           if !name_part && use_qualified_names? && shard.name

--- a/lib/switchman/active_record/query_cache.rb
+++ b/lib/switchman/active_record/query_cache.rb
@@ -51,7 +51,7 @@ module Switchman
 
       def select_all(arel, name = nil, binds = [])
         if self.query_cache_enabled && !locked?(arel)
-          arel, binds = binds_from_relation(arel, binds) unless ::Rails.version < '4'
+          arel, binds = binds_from_relation(arel, binds) unless ::Rails.version < '4'.freeze
           sql = to_sql(arel, binds)
           cache_sql(sql, binds) { super(sql, name, binds) }
         else

--- a/lib/switchman/active_record/query_methods.rb
+++ b/lib/switchman/active_record/query_methods.rb
@@ -12,7 +12,7 @@ module Switchman
       #                  for foreign key transposition
       #   :to_a        - a special value that Relation#to_a uses when querying multiple shards to
       #                  remove primary keys from conditions that aren't applicable to the current shard
-      if ::Rails.version < '4'
+      if ::Rails.version < '4'.freeze
         attr_accessor :shard_value, :shard_source_value
       else
         def shard_value
@@ -32,7 +32,7 @@ module Switchman
       end
 
       def shard(value, source = :explicit)
-        (::Rails.version < '4' ? clone : spawn).shard!(value, source)
+        (::Rails.version < '4'.freeze ? clone : spawn).shard!(value, source)
       end
 
       def shard!(value, source = :explicit)

--- a/lib/switchman/active_record/relation.rb
+++ b/lib/switchman/active_record/relation.rb
@@ -15,7 +15,7 @@ module Switchman
 
       def initialize_with_sharding(*args)
         initialize_without_sharding(*args)
-        self.shard_value = Shard.current(klass.try(:shard_category) || :default) unless shard_value
+        self.shard_value = Shard.current(klass.respond_to?(:shard_category) ? klass.shard_category : :default) unless shard_value
         self.shard_source_value = :implicit unless shard_source_value
       end
 

--- a/lib/switchman/arel.rb
+++ b/lib/switchman/arel.rb
@@ -16,10 +16,10 @@ module Switchman
 
         def visit_Arel_Attributes_Attribute *args
           o = args.first
-          self.last_column = column_for(o) if ::Rails.version < '4.0'
+          self.last_column = column_for(o) if ::Rails.version < '4.0'.freeze
           join_name = o.relation.table_alias || o.relation.name
           result = "#{quote_local_table_name join_name}.#{quote_column_name o.name}"
-          unless ::Rails.version < '4.2'
+          unless ::Rails.version < '4.2'.freeze
             result = args.last << result
           end
           result

--- a/lib/switchman/connection_pool_proxy.rb
+++ b/lib/switchman/connection_pool_proxy.rb
@@ -35,9 +35,10 @@ module Switchman
     end
 
     def current_pool
-      pool = self.default_pool if active_shard.database_server == Shard.default.database_server && active_shackles_environment == :master && (active_shard == Shard.default || active_shard.database_server.shareable?)
+      current_active_shard = active_shard
+      pool = self.default_pool if current_active_shard.database_server == Shard.default.database_server && active_shackles_environment == :master && (current_active_shard.default? || current_active_shard.database_server.shareable?)
       pool = @connection_pools[pool_key] ||= create_pool unless pool
-      pool.shard = active_shard
+      pool.shard = current_active_shard
       pool
     end
 

--- a/lib/switchman/database_server.rb
+++ b/lib/switchman/database_server.rb
@@ -184,7 +184,7 @@ module Switchman
               shard.name = name
             end
           end
-          shard.activate(Shard.categories) do
+          shard.activate(*Shard.categories) do
             ::Shackles.activate(:deploy) do
               begin
                 if create_statement


### PR DESCRIPTION
I've been looking into the performance of Switchman and have some ideas for optimizations. This PR should be considered more of a discussion than something I'd expect to be pulled in directly. I'm sure there are things I'm not considering so I'm looking for feedback.

So far I've been able to get `Shard#activate` to be at least 5x faster and reduce object allocations considerably. It can be 8x+ faster with some changes to the delayed job overrides in Canvas.

Switchman makes a LOT of calls to `activate` to make sure the active shards are enabled. After each call, if the active shards were changed, they are restored to their original values. In a standard case, the `:default` shard should be active and should not be changing very often (or ever?). And in a very simple setup (single shard) the active shards would never change.

I've created a benchmark script to help profile where the time is spent and objects are allocated.
https://gist.github.com/dgynn/f4f0f7552db3653d4e67
This script defines a FastShard class which is the equivalent of the changes in this branch. It then compares what calling `activate` 

```ruby
Comparing .activate
Calculating -------------------------------------
      shard.activate    10.964k i/100ms
 fastshard1.activate    31.866k i/100ms
-------------------------------------------------
      shard.activate    154.968k (±15.1%) i/s -    767.480k
 fastshard1.activate    847.485k (±25.7%) i/s -      3.696M

Comparison:
 fastshard1.activate:   847485.3 i/s
      shard.activate:   154967.9 i/s - 5.47x slower
# Note: These results are with delayed jobs activate overrides commented out
# since that is a better with FastShard which also does not have those methods include
```

So far I've been focused on the simple case of a single shard where the active shards have been pre-activated for :default and :delayed_jobs. The Canvas switchman initializer already pre-activates the default :delayed_job shard. This branch now also pre-activates the :default shard when it is set.
```ruby
# effectively...
Shard.send(:active_shards) == { :default => Shard.default, :delayed_jobs => Shard.default }
```
The improvements on this branch should still be helpful even if the most-likely shards have not been activated.

A few observations:
* On a single `activate` call, 30% of the time is spent doing the `flatten` call in `hashify_categories`. This is old Ruby 1.8.6 style code and works poorly with ActiveRecord. `flatten` tries to turn every Shard into an array to see if it can be flattened. That is a quick, easy win.
* On a single `activate` call, 30% of the time is spent in `delayed_jobs_shard`, even if that shard is already active. Memoizing or eliminating those patches would be helpful. In my environment I've commented them out.
* It would be great to remove the complexity of `DefaultShard` if that was possible. A lot of time is spent comparing shards or checking for default. 

I'm interested in any feedback on this PR and any input on what a better test case would be. I don't have a good idea of what a more complex Switchman setup would be, especially around delayed jobs shards. The specs for switchman still pass but I would imagine the specs for Canvas would fail (primarily by the removal of the `==` override).

Thanks!
