### PR TITLE
Remove reloader hook for DefaultShard

### DIFF
--- a/app/models/switchman/shard.rb
+++ b/app/models/switchman/shard.rb
@@ -1,6 +1,6 @@
-require_dependency 'switchman/database_server'
-require_dependency 'switchman/default_shard'
-require_dependency 'switchman/environment'
+require 'switchman/database_server'
+require 'switchman/default_shard'
+require 'switchman/environment'
 
 module Switchman
   class Shard < ::ActiveRecord::Base

--- a/lib/switchman/active_record/connection_handler.rb
+++ b/lib/switchman/active_record/connection_handler.rb
@@ -1,5 +1,5 @@
-require_dependency 'switchman/connection_pool_proxy'
-require_dependency 'switchman/shard'
+require 'switchman/connection_pool_proxy'
+require 'switchman/shard'
 
 module Switchman
   module ActiveRecord

--- a/lib/switchman/default_shard.rb
+++ b/lib/switchman/default_shard.rb
@@ -1,4 +1,4 @@
-require_dependency 'switchman/database_server'
+require 'switchman/database_server'
 
 module Switchman
   class DefaultShard

--- a/lib/switchman/engine.rb
+++ b/lib/switchman/engine.rb
@@ -189,12 +189,5 @@ module Switchman
       end
     end
 
-    initializer 'switchman.set_reloader_hooks', :before => "active_record.set_reloader_hooks" do |app|
-      ::ActiveSupport.on_load(:active_record) do
-        ActionDispatch::Reloader.to_prepare do
-          require_dependency 'switchman/default_shard'
-        end
-      end
-    end
   end
 end

--- a/lib/switchman/r_spec_helper.rb
+++ b/lib/switchman/r_spec_helper.rb
@@ -1,4 +1,4 @@
-require_dependency "switchman/test_helper"
+require "switchman/test_helper"
 
 module Switchman
   # including this module in your specs will give you several shards to

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../dummy/config/environment", __FILE__)
 require 'rspec/rails'
 
-require_dependency 'switchman/r_spec_helper'
+require 'switchman/r_spec_helper'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
Since Shard is no longer reloadable (with 2c6a391f) the DefaultShard does not need to be reloaded either.

With this change, it is possible to update the Canvas `config/initializers/switchman.rb` to wrap the initializer code in an `after_initialize` block instead of a `to_prepare` block so that it only gets run once in development.

```diff
--- a/config/initializers/switchman.rb
+++ b/config/initializers/switchman.rb
@@ -1,4 +1,4 @@
-Rails.application.config.to_prepare do
+Rails.application.config.after_initialize do
```